### PR TITLE
Update OpenAPIKit to alpha.9 and fix break change

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mattpolzin/OpenAPIKit.git",
         "state": {
           "branch": null,
-          "revision": "d40e6c3d57b1b27ac2114861d5a83cf8ee9d206d",
-          "version": "3.0.0-alpha.6"
+          "revision": "e805233e54afd394937cecb0a28e575b3388f60f",
+          "version": "3.0.0-alpha.9"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -32,7 +32,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/tachyonics/SwaggerParser.git", from: "0.6.4"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
-        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "3.0.0-alpha.4"),
+        .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "3.0.0-alpha.9"),
         .package(url: "https://github.com/amzn/service-model-swift-code-generate", from: "3.0.0")
     ],
     targets: [

--- a/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
+++ b/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
@@ -81,7 +81,7 @@ internal extension OpenAPIServiceModel {
         for (path, pathDefinition) in definition.paths {
             var operations:[OpenAPI.HttpMethod: OpenAPI.Operation] = [:]
             
-            pathDefinition.endpoints.forEach { endpoint in
+            pathDefinition.pathItemValue?.endpoints.forEach { endpoint in
                 operations[endpoint.method] = endpoint.operation
             }
             

--- a/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
+++ b/Sources/OpenAPIServiceModel/CreateOpenAPIServiceModel.swift
@@ -81,7 +81,7 @@ internal extension OpenAPIServiceModel {
         for (path, pathDefinition) in definition.paths {
             var operations:[OpenAPI.HttpMethod: OpenAPI.Operation] = [:]
             
-            pathDefinition.pathItemValue?.endpoints.forEach { endpoint in
+            definition.components[pathDefinition]?.endpoints.forEach { endpoint in
                 operations[endpoint.method] = endpoint.operation
             }
             


### PR DESCRIPTION
*Issue #, if available:*

At OpenAPIKit 3.0.0-alpha.9, OpenAPIKit change `Document.paths`.value from OpenAPI.PathItem to `<JSONReference<OpenAPI.PathItem>, OpenAPI.PathItem>`

It is break change. We need to modify code to compatible with it


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.