### PR TITLE
Update SwaggerParser repository location because original is 404

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -21,7 +21,7 @@
       },
       {
         "package": "SwaggerParser",
-        "repositoryURL": "https://github.com/tachyonics/SwaggerParser.git",
+        "repositoryURL": "https://github.com/knovichikhin/SwaggerParser.git",
         "state": {
           "branch": null,
           "revision": "c0eb70485c59a9d7dd6765dcd303b49fdb3040ee",

--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
             targets: ["OpenAPIServiceModel"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/tachyonics/SwaggerParser.git", from: "0.6.4"),
+        .package(url: "https://github.com/knovichikhin/SwaggerParser.git", from: "0.6.4"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "4.0.0"),
         .package(url: "https://github.com/mattpolzin/OpenAPIKit.git", from: "3.0.0-alpha.9"),
         .package(url: "https://github.com/amzn/service-model-swift-code-generate", from: "3.0.0")


### PR DESCRIPTION
*Issue #, if available:*
SwaggerParser is 404. Re-created a fork

*Description of changes:*
Update SwaggerParser to point to a fork. All code is the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.